### PR TITLE
Connected Momentum Tabs (Issue 1) to Airtable 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -103,11 +103,11 @@ module.exports = {
     {
       resolve: 'gatsby-source-airtable',
       options: {
-        apiKey: 'keyF2AGHFec4RxFTY',
+        apiKey: 'keyl3VyMD42AADPXx',
         tables: [
           {
-            baseId: 'appQ1ZjraW0ndi4f0',
-            tableName: 'testTable'
+            baseId: 'appToqMlXxkmbbwTr',
+            tableName: 'Interactive Bibliography'
           }
         ]
       }

--- a/src/components/issues-hero.js
+++ b/src/components/issues-hero.js
@@ -7,7 +7,7 @@ import "./issues-hero.scss"
 class IssuesHero extends React.Component {
   render(){
     return (
-      <Jumbotron fluid className="pt-5 pb-4 issuesHeroWrap">
+      <Jumbotron fluid className="pt-5 pb-4 bg-dark issuesHeroWrap">
         <Container>
           <Row className="justify-content-center">
             <Col className="justify-content-center p-0" sm="3">

--- a/src/components/issues-hero.scss
+++ b/src/components/issues-hero.scss
@@ -1,8 +1,6 @@
 @import "../styles/_custom.scss";
 
 .issuesHeroWrap {
-  background: $dark;
-  
   .issueImage {
     margin-bottom: -1.5rem;
     position: relative;

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -32,6 +32,8 @@ class MomentumTabs extends React.Component {
 
     // Reverse order of years
     const docsByYearReverse = docsByYearArray.sort().reverse();
+
+    console.log(docsByYearReverse)
     
     return (
       <Row className="justify-content-center mt-2 momentum">
@@ -54,32 +56,34 @@ class MomentumTabs extends React.Component {
                 <Tab.Content key={ item.year }>
                   <Tab.Pane eventKey={ item.year } className="momentum-pane">
                     <Row>
+                      <Tab.Container>
                         <Col sm="6" className="article-list">
-                          {item.docs.map(doc => (
-                            <Nav key={ doc.Title.slice(0,5) } variant="link">
-                              <Nav.Item>
-                                <Nav.Link eventKey={ doc.Title.slice(0,5) } className="article-item align-items-center">
-                                  <p className="article-heading display-4">
+                            <Nav variant="link">
+                            {item.docs.map(doc => (
+                              <Nav.Item key={ doc.Title.slice(0,4) } className="article-item">
+                                <Nav.Link eventKey={ doc.Title.slice(0,4) } className="article-heading display-4 align-items-center">
                                   { doc.Title }
-                                  </p>
                                 </Nav.Link>
                               </Nav.Item>
+                              ))}
                             </Nav>
+                        </Col>
+                        <Col sm="6" className="article-preview">
+                          {item.docs.map(doc => (
+                            <div className="article-card">
+                              <div className="article-header">
+                                <div className="source">{ doc.Author_s_ }</div>
+                                <div className="date">{ doc.Publish__or_Start_Date_ }</div>
+                              </div>
+                              <div className="article-body">
+                                <b>{ doc.Title }</b>
+                                <p>{ doc.Momentum_Annotation }</p>
+                                <a href="{ doc.URL }">Read More &raquo;</a>
+                              </div>
+                            </div>
                           ))}
                         </Col>
-
-                        <Col sm="6" className="article-preview">
-                          <div className="article-card">
-                            <div className="article-header">
-                              <div className="source">HuffPost</div>
-                              <div className="date">03/21/2020</div>
-                            </div>
-                            <div className="article-body">
-                              <b>Article Snippet</b>
-                              <p>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Maecenas faucibus mollis interdum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</p>
-                            </div>
-                          </div>
-                        </Col>
+                      </Tab.Container>
                     </Row>
                   </Tab.Pane>
                 </Tab.Content>

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -4,19 +4,19 @@ import "./issues-momentum.scss"
 
 class MomentumTabs extends React.Component {
   render() {
-    /* Functions to Transform Airtable Articles Data */
+    // Rename data to make it more legible
     const airtable = this.props.documents
     // console.log(airtable)
-    // console.log(typeof airtable)
 
     // Temp storage of keys
     const docsByYear = {};
     // Check that data was fetched
-    if (airtable && Object.keys(airtable)) {
+    if (/*airtable &&*/ Object.keys(airtable)) {
       // Group docs from same year
-      Object.keys(airtable).forEach(function(key) {
+      Object.keys(airtable).forEach(function(i) {
+        console.log(typeof airtable[i].data.Publish__or_Start_Date_)
         // Create key for grouping
-        var tempKey = airtable[key].data.Date.slice(0,4);
+        var tempKey = airtable[i].data.Publish__or_Start_Date_.slice(0,4);
         if (!docsByYear.hasOwnProperty(tempKey)) {
           docsByYear[tempKey] = {
             "year": tempKey,
@@ -24,7 +24,7 @@ class MomentumTabs extends React.Component {
           }
         }
         // push docs into the nested array under the year
-        docsByYear[tempKey].docs.push(airtable[key].data);
+        docsByYear[tempKey].docs.push(airtable[i].data);
       });
     }
     // Map objects to final results array

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -37,7 +37,7 @@ class MomentumTabs extends React.Component {
     
     return (
       <Row className="justify-content-center mt-2 momentum">
-        <Col md="11" >
+        <Col md="8" >
           <Tab.Container defaultActiveKey="2020">
             <Row>
                 { docsByYearReverse.map(item => (
@@ -56,22 +56,24 @@ class MomentumTabs extends React.Component {
                 <Tab.Content key={ item.year }>
                   <Tab.Pane eventKey={ item.year } className="momentum-pane">
                     <Row>
-                      <Tab.Container>
+                      <Tab.Container defaultActiveKey="0">
                         <Col sm="6" className="article-list">
                             <Nav variant="link">
-                            {item.docs.map(doc => (
-                              <Nav.Item key={ doc.Title.slice(0,4) } className="article-item">
-                                <Nav.Link eventKey={ doc.Title.slice(0,4) } className="article-heading display-4 align-items-center">
+                            {item.docs.map(function(doc, index) {
+                              return (
+                              <Nav.Item key={ index } className="article-item">
+                                <Nav.Link eventKey={ index } className="article-heading display-4 align-items-center">
                                   { doc.Title }
                                 </Nav.Link>
                               </Nav.Item>
-                              ))}
+                              )})}
                             </Nav>
                         </Col>
                         <Col sm="6" className="article-preview">
-                          {item.docs.map(doc => (
-                            <Tab.Content key={ doc.Title.slice(0,4) }>
-                              <Tab.Pane eventKey={ doc.Title.slice(0,4) } className="article-card">
+                          {item.docs.map(function(doc, index) {
+                            return (
+                            <Tab.Content key={ index }>
+                              <Tab.Pane eventKey={ index } className="article-card">
                                 <div className="article-header">
                                   <div className="source">{ doc.Author_s_ }</div>
                                   <div className="date">{ doc.Publish__or_Start_Date_ }</div>
@@ -83,7 +85,7 @@ class MomentumTabs extends React.Component {
                                 </div>
                               </Tab.Pane>
                             </Tab.Content>
-                          ))}
+                          )})}
                         </Col>
                       </Tab.Container>
                     </Row>

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -6,15 +6,13 @@ class MomentumTabs extends React.Component {
   render() {
     // Rename data to make it more legible
     const airtable = this.props.documents
-    // console.log(airtable)
 
     // Temp storage of keys
     const docsByYear = {};
     // Check that data was fetched
-    if (/*airtable &&*/ Object.keys(airtable)) {
+    if (airtable && Object.keys(airtable)) {
       // Group docs from same year
       Object.keys(airtable).forEach(function(i) {
-        console.log(typeof airtable[i].data.Publish__or_Start_Date_)
         // Create key for grouping
         var tempKey = airtable[i].data.Publish__or_Start_Date_.slice(0,4);
         if (!docsByYear.hasOwnProperty(tempKey)) {
@@ -31,8 +29,6 @@ class MomentumTabs extends React.Component {
     const docsByYearArray = Object.keys(docsByYear).map(function(key) {
       return docsByYear[key];
     })
-    // console.log(docsByYearArray)
-    // console.log(typeof docsByYearArray)
 
     /*Reverse order of years*/
     const docsByYearReverse = docsByYearArray.sort().reverse();
@@ -62,7 +58,7 @@ class MomentumTabs extends React.Component {
                       <Row>
                         <Col sm="6" className="article-list">
                           {item.docs.map(doc => (
-                            <Row key={ item.recordId } className="no-gutters article-item">
+                            <Row key={ doc.key } className="no-gutters article-item">
                               <img src="https://placehold.it/100x100" alt="{ item.year }"/>
                               <div className="article-heading display-4">
                                 { doc.Title }

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -39,7 +39,7 @@ class MomentumTabs extends React.Component {
     
     return (
       <Row className="justify-content-center mt-2 momentum">
-        <Col md="8" >
+        <Col md="11" >
           <Tab.Container defaultActiveKey="2020">
             <Row>
               { docsByYearReverse.map(function(item) {

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -70,17 +70,19 @@ class MomentumTabs extends React.Component {
                         </Col>
                         <Col sm="6" className="article-preview">
                           {item.docs.map(doc => (
-                            <div className="article-card">
-                              <div className="article-header">
-                                <div className="source">{ doc.Author_s_ }</div>
-                                <div className="date">{ doc.Publish__or_Start_Date_ }</div>
-                              </div>
-                              <div className="article-body">
-                                <b>{ doc.Title }</b>
-                                <p>{ doc.Momentum_Annotation }</p>
-                                <a href="{ doc.URL }">Read More &raquo;</a>
-                              </div>
-                            </div>
+                            <Tab.Content key={ doc.Title.slice(0,4) }>
+                              <Tab.Pane eventKey={ doc.Title.slice(0,4) } className="article-card">
+                                <div className="article-header">
+                                  <div className="source">{ doc.Author_s_ }</div>
+                                  <div className="date">{ doc.Publish__or_Start_Date_ }</div>
+                                </div>
+                                <div className="article-body">
+                                  <b>{ doc.Title }</b>
+                                  <p>{ doc.Momentum_Annotation }</p>
+                                  <a href="{ doc.URL }">Read More &raquo;</a>
+                                </div>
+                              </Tab.Pane>
+                            </Tab.Content>
                           ))}
                         </Col>
                       </Tab.Container>

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -30,7 +30,7 @@ class MomentumTabs extends React.Component {
       return docsByYear[key];
     })
 
-    /*Reverse order of years*/
+    // Reverse order of years
     const docsByYearReverse = docsByYearArray.sort().reverse();
     
     return (
@@ -59,8 +59,8 @@ class MomentumTabs extends React.Component {
                         <Col sm="6" className="article-list">
                           {item.docs.map(doc => (
                             <Row key={ doc.key } className="no-gutters article-item">
-                              <img src="https://placehold.it/100x100" alt="{ item.year }"/>
-                              <div className="article-heading display-4">
+                              <div className="article-item-bg" style={{backgroundImage: `url(http://placekitten.com/g/400/100)`}} alt="{ item.year }"/>
+                              <div className="article-heading display-3">
                                 { doc.Title }
                               </div>
                             </Row>

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -50,6 +50,7 @@ class MomentumTabs extends React.Component {
                 )
               })}
             </Row>
+
             <Row className="pl-2 pr-2">
               { docsByYearReverse.map(function(item) {
                 return (
@@ -57,14 +58,29 @@ class MomentumTabs extends React.Component {
                     <Tab.Pane eventKey={ item.year } className="momentum-pane">
                       <Row>
                         <Col sm="6" className="article-list">
+                          {/* Navigation tabs for each article */}
+                          <Col>
+                            { item.docs.map(doc => (
+                              <Nav key={ doc.key } variant="link">
+                                <Nav.Item >
+                                  <Nav.Link eventKey={ doc.key } className="article-item">
+                                    <div className="article-heading display-3">
+                                      { doc.Title }
+                                    </div>
+                                  </Nav.Link>
+                                </Nav.Item>
+                              </Nav>
+                            ))}
+                          </Col>
+
+                          {/* EXAMPLE MAPPING
                           {item.docs.map(doc => (
                             <Row key={ doc.key } className="no-gutters article-item">
-                              <div className="article-item-bg" style={{backgroundImage: `url(http://placekitten.com/g/400/100)`}} alt="{ item.year }"/>
                               <div className="article-heading display-3">
                                 { doc.Title }
                               </div>
                             </Row>
-                          ))}
+                          ))} */}
                         </Col>
                         <Col sm="6" className="article-preview">
                           <div className="article-card">

--- a/src/components/issues-momentum.js
+++ b/src/components/issues-momentum.js
@@ -38,8 +38,7 @@ class MomentumTabs extends React.Component {
         <Col md="11" >
           <Tab.Container defaultActiveKey="2020">
             <Row>
-              { docsByYearReverse.map(function(item) {
-                return (
+                { docsByYearReverse.map(item => (
                   <Nav key={ item.year } variant="link" className="flex momentum-tab-row">
                     <Nav.Item className="momentum-tab">
                       <Nav.Link eventKey={ item.year }>
@@ -47,41 +46,28 @@ class MomentumTabs extends React.Component {
                       </Nav.Link>
                     </Nav.Item>
                   </Nav>
-                )
-              })}
+                ))}
             </Row>
 
             <Row className="pl-2 pr-2">
-              { docsByYearReverse.map(function(item) {
-                return (
-                  <Tab.Content key={ item.year }>
-                    <Tab.Pane eventKey={ item.year } className="momentum-pane">
-                      <Row>
+              { docsByYearReverse.map(item => (
+                <Tab.Content key={ item.year }>
+                  <Tab.Pane eventKey={ item.year } className="momentum-pane">
+                    <Row>
                         <Col sm="6" className="article-list">
-                          {/* Navigation tabs for each article */}
-                          <Col>
-                            { item.docs.map(doc => (
-                              <Nav key={ doc.key } variant="link">
-                                <Nav.Item >
-                                  <Nav.Link eventKey={ doc.key } className="article-item">
-                                    <div className="article-heading display-3">
-                                      { doc.Title }
-                                    </div>
-                                  </Nav.Link>
-                                </Nav.Item>
-                              </Nav>
-                            ))}
-                          </Col>
-
-                          {/* EXAMPLE MAPPING
                           {item.docs.map(doc => (
-                            <Row key={ doc.key } className="no-gutters article-item">
-                              <div className="article-heading display-3">
-                                { doc.Title }
-                              </div>
-                            </Row>
-                          ))} */}
+                            <Nav key={ doc.Title.slice(0,5) } variant="link">
+                              <Nav.Item>
+                                <Nav.Link eventKey={ doc.Title.slice(0,5) } className="article-item align-items-center">
+                                  <p className="article-heading display-4">
+                                  { doc.Title }
+                                  </p>
+                                </Nav.Link>
+                              </Nav.Item>
+                            </Nav>
+                          ))}
                         </Col>
+
                         <Col sm="6" className="article-preview">
                           <div className="article-card">
                             <div className="article-header">
@@ -94,11 +80,10 @@ class MomentumTabs extends React.Component {
                             </div>
                           </div>
                         </Col>
-                      </Row>
-                    </Tab.Pane>
-                  </Tab.Content>
-                )
-              })}
+                    </Row>
+                  </Tab.Pane>
+                </Tab.Content>
+              ))}
             </Row>
           </Tab.Container>
         </Col>

--- a/src/components/issues-momentum.scss
+++ b/src/components/issues-momentum.scss
@@ -33,6 +33,7 @@
 
       .article-item {
         position: relative;
+        display: flex;
         flex: 1;
         padding: 0.4rem 0.8rem;
         min-height: 150px;
@@ -64,18 +65,12 @@
         }
       }
 
-      .article-thumb {
-        background: grey;
-        height: 100px;
-        width: 100px;
-      }
-
       .article-heading {
         flex: 1;
         display: flex;
         align-items: center;
         padding: 1rem;
-        color: white;
+        color: white !important;
       }
     }
 

--- a/src/components/issues-momentum.scss
+++ b/src/components/issues-momentum.scss
@@ -34,9 +34,8 @@
       .article-item {
         position: relative;
         display: flex;
-        flex: 1;
-        padding: 0.4rem 0.8rem;
-        min-height: 150px;
+        flex-direction: column;
+        min-height: 120px;
         z-index: 2;
         margin-bottom: 16px;
         background: $dark url('http://source.unsplash.com/random/800x600') no-repeat center;
@@ -66,10 +65,9 @@
       }
 
       .article-heading {
-        flex: 1;
         display: flex;
-        align-items: center;
-        padding: 1rem;
+        flex: 1;
+        padding: 1rem 2rem;
         color: white !important;
       }
     }

--- a/src/components/issues-momentum.scss
+++ b/src/components/issues-momentum.scss
@@ -49,13 +49,6 @@
         &:last-of-type {
           margin-bottom: 0;
         }
-
-        // This code will need to be changed once we introduce images via gatsby-image via content-source-airtable
-        .article-item-bg {
-          width: auto;
-          position: absolute;
-          z-index: -2;
-          }
         
         &:before {
           content: "";
@@ -82,6 +75,7 @@
         display: flex;
         align-items: center;
         padding: 1rem;
+        color: white;
       }
     }
 

--- a/src/components/issues-momentum.scss
+++ b/src/components/issues-momentum.scss
@@ -1,4 +1,5 @@
 @import "../styles/_custom.scss";
+@import "../styles/index.scss";
 
 .momentum {
   .momentum-tab-row {
@@ -37,7 +38,13 @@
         min-height: 150px;
         z-index: 2;
         margin-bottom: 16px;
-        background: $dark url('http://source.unsplash.com/random') no-repeat center;
+        background: $dark url('http://source.unsplash.com/random/800x600') no-repeat center;
+        background-size: 100%;
+        @include transition-300;
+
+        &:hover {
+          background-size: 150%;
+        }
         
         &:last-of-type {
           margin-bottom: 0;

--- a/src/components/issues-momentum.scss
+++ b/src/components/issues-momentum.scss
@@ -74,6 +74,7 @@
 
     .article-preview {
       padding: 2rem;
+      min-width: 45%;
 
       .article-card {
         background: white;

--- a/src/components/issues-momentum.scss
+++ b/src/components/issues-momentum.scss
@@ -31,10 +31,36 @@
       padding: 2rem;
 
       .article-item {
-        border: 1px $light solid;
+        position: relative;
+        flex: 1;
+        padding: 0.4rem 0.8rem;
+        min-height: 150px;
+        z-index: 2;
+        margin-bottom: 16px;
+        background: $dark url('http://source.unsplash.com/random') no-repeat center;
+        
+        &:last-of-type {
+          margin-bottom: 0;
+        }
 
-        img {
-          width: 100px;
+        // This code will need to be changed once we introduce images via gatsby-image via content-source-airtable
+        .article-item-bg {
+          width: auto;
+          position: absolute;
+          z-index: -2;
+          }
+        
+        &:before {
+          content: "";
+          background: linear-gradient(90deg,rgba(0,0,0,0.85),rgba(0,0,0,0.4));
+          position: absolute;
+          height: 100%;
+          width: 100%;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          z-index: -1;
         }
       }
 

--- a/src/pages/issue1.js
+++ b/src/pages/issue1.js
@@ -22,6 +22,7 @@ const Issue1Page = () => {
             data: { 
               Include_in_Momentum_: { in : "Theme 1 - Punish S&E Conditions" }
               Publish__or_Start_Date_: { ne: null }
+              Momentum_Annotation: { ne: null }
             }
           }
         ) {

--- a/src/pages/issue1.js
+++ b/src/pages/issue1.js
@@ -19,14 +19,20 @@ const Issue1Page = () => {
       }
       documents: allAirtable(
           filter: {
-            table: { eq: "testTable" }
+            data: { 
+              Include_in_Momentum_: { in : "Theme 1 - Punish S&E Conditions" }
+            }
           }
         ) {
           nodes {
             data {
               Title
+              Author_s_
+              URL
+              Include_in_Momentum_
+              Publish__or_Start_Date_
+              Momentum_Annotation
             }
-            recordId
           }
         }
     }

--- a/src/pages/issue1.js
+++ b/src/pages/issue1.js
@@ -25,10 +25,6 @@ const Issue1Page = () => {
           nodes {
             data {
               Title
-              Author
-              Date
-              Topic
-              Description
             }
             recordId
           }

--- a/src/pages/issue1.js
+++ b/src/pages/issue1.js
@@ -13,7 +13,7 @@ const Issue1Page = () => {
       issue1: file(relativePath: { eq: "images/issue1.jpg" }) {
         childImageSharp {
           fixed(width: 300) {
-            ...GatsbyImageSharpFixed_tracedSVG
+            ...GatsbyImageSharpFixed
           }
         }
       }

--- a/src/pages/issue1.js
+++ b/src/pages/issue1.js
@@ -21,6 +21,7 @@ const Issue1Page = () => {
           filter: {
             data: { 
               Include_in_Momentum_: { in : "Theme 1 - Punish S&E Conditions" }
+              Publish__or_Start_Date_: { ne: null }
             }
           }
         ) {
@@ -51,7 +52,7 @@ const Issue1Page = () => {
       </Row>
 
       <Row className="justify-content-center pb-5">
-        <Col md="12" lg="10">
+        <Col md="12">
           <MomentumTabs documents={ data.documents.nodes } />
         </Col>
       </Row>

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -317,7 +317,7 @@ $headings-line-height:        1.2 !default;
 $display1-size:               5.5rem !default;
 $display2-size:               3rem !default;
 $display3-size:               2rem !default;
-$display4-size:               1.25rem !default;
+$display4-size:               1.5rem !default;
 
 // $display1-weight:             300 !default;
 // $display2-weight:             300 !default;

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -288,7 +288,7 @@ $font-family-headings:         Martin, "Arial Condensed Black", Impact, -apple-s
 // // stylelint-enable value-keyword-case
 
 
-$font-size-base:              1rem !default; // Slightly bigger than the browser default since Crimson Text has a smaller x-height - typically 18px
+$font-size-base:              1.25rem !default; // Slightly bigger than the browser default since Crimson Text has a smaller x-height - typically 18px
 // $font-size-lg:                $font-size-base * 1.25 !default;
 // $font-size-sm:                $font-size-base * .875 !default;
 


### PR DESCRIPTION
**Changes:**

- [x] Linked up the Bail Reform project's[ Airtable bibliography](https://airtable.com/tblKI8NeszDqdDEsY/viwdIdCr3JwpwxqMM?blocks=hide)
- [x] Updated query code (located just in `issue1.js` for now) to check for records with the date set to `null` - my code requires a date field for every record, or else it doesn't show up in the Momentum tabbed component
- [x] Convert each article list (within each year) to a second tier of tabs
- [x] Code the preview pane to populate with Airtable data (date, author, snippet)

**To Do Next:**
- [ ] Add an image column to the bibliography in Airtable (min 800x200px)
- [ ] Update the article list under each year tab to pull the image from Airtable